### PR TITLE
send HOLOCHAIN_WEBSOCKET_CONNECTED on reconnect events too

### DIFF
--- a/src/lib/middleware.ts
+++ b/src/lib/middleware.ts
@@ -12,7 +12,9 @@ export const holochainMiddleware = (hcWc: hcWebClientConnect): Middleware => sto
   // this is how we persist a websocket connection
 
   const connectPromise = hcWc.then(({ call, callZome, ws }) => {
-    store.dispatch({ type: 'HOLOCHAIN_WEBSOCKET_CONNECTED' })
+    ws.on('open', () => {
+      store.dispatch({ type: 'HOLOCHAIN_WEBSOCKET_CONNECTED' })
+    })
 
     ws.on('close', () => {
       store.dispatch({ type: 'HOLOCHAIN_WEBSOCKET_DISCONNECTED' })


### PR DESCRIPTION
When the conductor shuts down, then comes back online, I thought "why isn't it reconnecting", as I was watching the 'redux-dev-tools' action logger. 

So this change just makes it so that instead of dispatching HOLOCHAIN_WEBSOCKET_CONNECTED only on the first connection to the websocket server, it will dispatch it on subsequent connections/reconnections too.

